### PR TITLE
docs: standardize README to Open Paws ecosystem template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,56 @@
-# Open Paws — CodeRabbit Central Config
+<!-- tech_stack: YAML, GitHub Actions, Semgrep, pre-commit -->
+<!-- project_status: active -->
+<!-- difficulty: beginner -->
+<!-- skill_tags: configuration, code-review, ci-cd, advocacy-language -->
+<!-- related_repos: no-animal-violence, semgrep-rules-no-animal-violence, desloppify, platform, gary -->
 
-![Maintenance](https://img.shields.io/badge/status-maintenance-blue)
-[![Open Paws Ecosystem](https://img.shields.io/badge/ecosystem-Open%20Paws-green)](https://github.com/Open-Paws)
+# Open Paws — CodeRabbit Config
 
-Org-wide default CodeRabbit configuration for every repository in the Open Paws GitHub organization.
+[![Maintenance](https://img.shields.io/badge/status-active-brightgreen)](https://github.com/Open-Paws/coderabbit)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![Open Paws](https://img.shields.io/badge/org-Open%20Paws-green)](https://github.com/Open-Paws)
+[![no-animal-violence](https://img.shields.io/badge/language-no--animal--violence-orange)](https://github.com/Open-Paws/no-animal-violence)
+
+## TL;DR
+
+This repo holds the org-wide [CodeRabbit](https://coderabbit.ai) configuration for every repository in the Open Paws GitHub organization. A single `.coderabbit.yaml` here applies automatically to any repo that does not define its own. It enforces compassionate language rules, secret scanning, test quality standards, and movement-correct terminology on every pull request across the ecosystem.
+
+> [!NOTE]
+> Open Paws is a 501(c)(3) nonprofit building open-source infrastructure for animal liberation. CodeRabbit runs at the org level so that advocacy-domain standards — farmed animal terminology, three-adversary security, and mutation-tested quality gates — are consistent across all campaigns, investigation tooling, platform code, and agent infrastructure without needing to configure each repo individually.
 
 ---
 
-## What is CodeRabbit?
+## Config overview
 
-[CodeRabbit](https://coderabbit.ai) is an AI-powered code review tool that integrates with GitHub pull requests. It reads a `.coderabbit.yaml` configuration file and applies automated review logic — flagging issues, suggesting fixes, scanning for security problems, and enforcing team standards — on every PR.
+### File inventory
 
-Open Paws runs CodeRabbit at the **org level**: a single configuration in this repo applies automatically to every Open Paws repository that does not define its own `.coderabbit.yaml`. This keeps the review baseline consistent across all campaigns, investigation tooling, platform code, and agent infrastructure.
-
----
-
-## How inheritance works
-
-| Repo state | Effective config |
+| File | Purpose |
 |---|---|
-| No `.coderabbit.yaml` in the repo | This central config applies automatically |
-| Has `.coderabbit.yaml` **without** `inheritance: true` | Repo config fully replaces this config |
-| Has `.coderabbit.yaml` **with** `inheritance: true` at the top | Repo config merges on top of this config |
+| `.coderabbit.yaml` | Org-wide CodeRabbit defaults |
+| `semgrep-no-animal-violence.yaml` | Imports the full [no-animal-violence rule set](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) for Semgrep |
+| `.pre-commit-config.yaml` | Pre-commit hook: runs no-animal-violence check locally |
+| `.github/workflows/auto-merge.yml` | Wave 0 auto-merge gate (deployable to target repos) |
+| `.github/workflows/no-animal-violence.yml` | CI check for speciesist language on every PR |
 
-To extend rather than replace, add `inheritance: true` as the first line of the repo-level `.coderabbit.yaml`.
+### Review behavior
 
----
-
-## What this config sets
-
-### Review profile
-
-- **Assertive** profile — flags issues without being overly verbose
-- `request_changes_workflow: true` — CodeRabbit can block merges when it finds errors; required for the Wave 0 auto-merge gate
-- High-level PR summary enabled; poem disabled; effort estimation enabled
-- Auto-incremental reviews on each push; no review on draft PRs
+- **Profile:** assertive — flags actionable issues without verbosity
+- `request_changes_workflow: true` — CodeRabbit can block merges; required for the Wave 0 auto-merge gate
+- High-level PR summary enabled; effort estimation enabled; decorative poem disabled
+- Auto-incremental reviews on each push; draft PRs skipped
+- Skips reviews for PRs titled `WIP` or `DO NOT MERGE`
 - Ignores `dependabot[bot]` and `renovate[bot]` commits
-- Skips reviews for PRs with `WIP` or `DO NOT MERGE` in the title
 
 ### Automatic labeling
 
-CodeRabbit suggests (but does not auto-apply) two labels:
+CodeRabbit suggests (does not auto-apply) two labels:
 
-- `security` — changes touching authentication, secrets, or coalition/activist data
-- `breaking-change` — removals or alterations of public API contracts, endpoints, or schemas
+| Label | Trigger |
+|---|---|
+| `security` | Changes touching authentication, secrets, or coalition/activist data |
+| `breaking-change` | Removals or alterations of public API contracts, endpoints, or schemas |
 
-### Path filters
-
-The following are excluded from review:
+### Path filters (excluded from review)
 
 - `dist/**`, `node_modules/**`
 - `**/*.lock`, `**/*.generated.*`
@@ -57,53 +60,19 @@ The following are excluded from review:
 
 | Path pattern | What CodeRabbit checks |
 |---|---|
-| `**/*.test.{ts,js,py}` | Three-question test quality check: would it fail on breakage? does it encode a domain rule? would mutation testing kill it? Rejects snapshot traps, coverage theater, and happy-path-only tests. |
+| `**/*.test.{ts,js,py}` | Three-question test quality: would it fail on breakage? does it encode a domain rule? would mutation testing kill it? Rejects snapshot traps, coverage theater, and happy-path-only tests. |
 | `.claude/**` | Scans for hidden Unicode (Rules File Backdoor attack). Flags hooks that expand scope. Confirms no activist identities or investigation names are embedded in instruction files. |
 
 ### Pre-merge checks (hard errors)
 
-Two checks run as **errors** — they block merge:
+Two custom checks run as **errors** and block merge:
 
 1. **No hardcoded secrets** — fails if any non-test file contains API keys, tokens, passwords, database URLs, or service account credentials
-2. **No speciesist idioms** — fails if code, comments, variable names, or docs contain terms from the no-animal-violence pattern list (e.g. `livestock` → `farmed animals`, `master/slave` → `primary/replica`, `whitelist/blacklist` → `allowlist/denylist`)
+2. **No speciesist idioms** — fails if code, comments, variable names, or docs contain terms from the no-animal-violence pattern list
 
 PR title format is checked as a **warning** (imperative verb, under 70 characters).
 
-### Finishing touches
-
-After each review CodeRabbit offers:
-
-- Unit test suggestions for uncovered code
-- Inline fixes for any speciesist idiom violations found in changed files
-
-### Static analysis tools
-
-| Tool | Purpose |
-|---|---|
-| Semgrep | Runs `semgrep-no-animal-violence.yaml` — imports the full Open Paws [no-animal-violence rule set](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) |
-| TruffleHog | Secret scanning on every PR |
-| GitHub Checks | CI status integration (90 s timeout) |
-| LanguageTool | Default-level prose linting |
-
-### Knowledge base
-
-- Reads `CLAUDE.md` and `AGENTS.md` files in each repo as code guidelines
-- Learnings, issues, and PRs are scoped **locally** per repo — no cross-repo leakage
-- Web search disabled
-- Jira, Linear, and MCP integrations disabled (MCP re-enable pending Gary MCP hub activation)
-
-### Chat
-
-- Auto-reply to `@coderabbitai` comments enabled
-- Decorative ASCII art disabled
-
----
-
-## Open Paws-specific standards enforced
-
-### Compassionate language (no-animal-violence)
-
-CodeRabbit hard-fails any PR that introduces speciesist idioms into code, comments, or documentation. Key mappings enforced:
+### Compassionate language enforced
 
 | Avoid | Use instead |
 |---|---|
@@ -117,78 +86,89 @@ CodeRabbit hard-fails any PR that introduces speciesist idioms into code, commen
 
 Full pattern list: [Open-Paws/no-animal-violence](https://github.com/Open-Paws/no-animal-violence)
 
-### Security (three-adversary model)
+### Static analysis tools
 
-Secret scanning via TruffleHog and the hardcoded-credentials pre-merge check guard against state surveillance, industry infiltration, and accidental data exposure. Sensitive repos (Tier 2/3) should additionally override `knowledge_base.opt_out: true` — see below.
+| Tool | Purpose |
+|---|---|
+| Semgrep | Runs `semgrep-no-animal-violence.yaml` — the full Open Paws [no-animal-violence rule set](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) |
+| TruffleHog | Secret scanning on every PR |
+| GitHub Checks | CI status integration (90 s timeout) |
+| LanguageTool | Default-level prose linting |
 
-### Test quality
+### Knowledge base
 
-Path instructions for test files enforce the mutation-testing mindset: every test must fail if the behavior it covers breaks. Snapshot traps and coverage theater are explicitly rejected.
+- Reads `CLAUDE.md` and `AGENTS.md` files in each repo as code guidelines
+- Learnings, issues, and PRs are scoped **locally** per repo — no cross-repo leakage
+- Web search disabled
+- Jira, Linear, and MCP integrations disabled (MCP re-enable pending Gary MCP hub activation)
 
-### Instruction file integrity
+### CI workflows
 
-The `.claude/**` path instruction scans for hidden Unicode characters — a known attack vector (Rules File Backdoor) where malicious instructions are embedded invisibly in CLAUDE.md or AGENTS.md files.
-
-### Movement terminology
-
-The tone instruction requires CodeRabbit to use movement-correct language in its review comments: `campaign`, `investigation`, `coalition`, `farmed animal`, `slaughterhouse`. It will not invent synonyms for these established domain terms.
-
----
-
-## Tier-based overrides
-
-Repos are classified by data sensitivity. See `ecosystem/repos.md` in the [context repo](https://github.com/Open-Paws/context) for current tier assignments.
-
-| Tier | Examples | Recommended override |
-|---|---|---|
-| Tier 1 (public, no sensitive data) | platform, desloppify, graze-cli | Use this config as-is |
-| Tier 2 (coalition or campaign data) | campaign tooling | `knowledge_base.opt_out: true` |
-| Tier 3 (investigation data, witness info, legal) | investigation ops, gary | `knowledge_base.opt_out: true` |
-
-### Minimal Tier 2/3 override
-
-```yaml
-# .coderabbit.yaml (repo root)
-inheritance: true   # keep all other org defaults
-
-knowledge_base:
-  opt_out: true     # disable KB for this repo — investigation data must not train models
-```
-
----
-
-## CI workflows in this repo
-
-This repo also ships two GitHub Actions workflows that can be deployed to target repos:
-
-### `auto-merge.yml` — Wave 0 auto-merge gate
+**`auto-merge.yml` — Wave 0 auto-merge gate**
 
 Merges `level-0` PRs automatically when all five gates pass:
 
-1. PR is labeled `level-0` (no external state changes, agent-confirmed safe)
+1. PR is labeled `level-0`
 2. All required CI checks pass
-3. Desloppify score meets repo threshold (Gary ≥80, platform ≥75, all others ≥70)
+3. Desloppify score meets the repo threshold (Gary ≥80, platform ≥75, all others ≥70)
 4. No-animal-violence scan has zero errors
-5. A validation agent (gary, validation-agent, or stuckvgn) has left an APPROVE review
+5. A validation agent (`gary`, `validation-agent`, or `stuckvgn`) has left an APPROVE review
 
-Hard safety constraints — auto-merge is **never** triggered when:
-- Changes touch `.env`, secret, credential, or key files
-- Changes modify `.github/workflows/` files
-- PR carries a `level-1`, `level-2`, `level-3`, or `needs-human-review` label
+Auto-merge is never triggered when changes touch `.env`, secret, credential, or key files, or when changes modify `.github/workflows/` files, or when the PR carries a `level-1`, `level-2`, `level-3`, or `needs-human-review` label.
 
-If any gate fails, the workflow adds `needs-human-review` and posts a comment listing which gates failed.
+**`no-animal-violence.yml` — speciesist language CI check**
 
-### `no-animal-violence.yml` — speciesist language CI check
-
-Runs `Open-Paws/no-animal-violence-action@v1` on every PR. Fails on errors; warnings do not block.
+Runs `Open-Paws/no-animal-violence-action@v1` on every PR. Errors block the PR; warnings do not.
 
 ---
 
-## Pre-commit hook
+## How to apply
 
-`.pre-commit-config.yaml` installs the no-animal-violence pre-commit hook for local development:
+### Org-wide default (no action needed)
+
+Any Open Paws repo without its own `.coderabbit.yaml` inherits this config automatically. No setup required.
+
+### Extend rather than replace
+
+To merge a repo-level config on top of this one, add `inheritance: true` as the first line of the repo's `.coderabbit.yaml`:
 
 ```yaml
+# .coderabbit.yaml (repo root)
+inheritance: true   # keep all org defaults; settings below are additive overrides
+```
+
+### Opt out knowledge base for sensitive repos
+
+Repos handling investigation data, witness information, or coalition ops should disable the knowledge base so that sensitive content does not train models:
+
+```yaml
+# .coderabbit.yaml (repo root)
+inheritance: true
+
+knowledge_base:
+  opt_out: true
+```
+
+### Tier reference
+
+| Tier | Examples | Recommended override |
+|---|---|---|
+| Tier 1 (public, no sensitive data) | platform, desloppify, graze-cli | Use org config as-is |
+| Tier 2 (coalition or campaign data) | campaign tooling | `knowledge_base.opt_out: true` |
+| Tier 3 (investigation data, witness info, legal) | investigation ops, gary | `knowledge_base.opt_out: true` |
+
+Tier assignments: `ecosystem/repos.md` in the [context repo](https://github.com/Open-Paws/context).
+
+### Deploy CI workflows to a target repo
+
+Copy `.github/workflows/auto-merge.yml` and `.github/workflows/no-animal-violence.yml` from this repo into the target repo's `.github/workflows/` directory. No other changes are needed — the workflows reference org-level actions and secrets.
+
+### Add the pre-commit hook
+
+To run speciesist-language checks locally before pushing, add the hook to the target repo:
+
+```yaml
+# .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Open-Paws/no-animal-violence-pre-commit
     rev: v1.0.0
@@ -199,13 +179,30 @@ repos:
 
 ---
 
-## Updating the org-wide config
+## Contributing
 
-1. Edit `.coderabbit.yaml` in this repo on a feature branch
-2. Validate against the schema: `yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json`
-3. Open a PR — the change affects every Open Paws repo that inherits this config, so treat it as a high-impact change
-4. After merge, CodeRabbit picks up the new config within minutes; no deployment step required
+Changes to `.coderabbit.yaml` affect every Open Paws repo that inherits this config — treat them as high-impact changes.
 
-The canonical source for the full config design is documented at:  
-`open-paws-strategy/roadmap/coderabbit-central-config.yaml`  
-Per-repo override configs: `open-paws-strategy/roadmap/coderabbit-repo-configs/`
+1. Create a feature branch from `main`
+2. Edit `.coderabbit.yaml` and validate against the schema declared at the top of the file (`yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json`)
+3. Open a PR with a description of what changes and why — include the repos most affected
+4. After merge, CodeRabbit picks up the new config within minutes; no deployment step is required
+
+The canonical design document for this config lives in the [context repo](https://github.com/Open-Paws/context) at `open-paws-strategy/roadmap/coderabbit-central-config.yaml`.
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- [CodeRabbit](https://coderabbit.ai) — AI code review platform
+- [Open-Paws/no-animal-violence](https://github.com/Open-Paws/no-animal-violence) — canonical speciesist language pattern list (65+ patterns)
+- [Open-Paws/semgrep-rules-no-animal-violence](https://github.com/Open-Paws/semgrep-rules-no-animal-violence) — Semgrep rule set
+- [Open-Paws/desloppify](https://github.com/Open-Paws/desloppify) — code quality scanner with advocacy language and security checks
+
+---
+
+[Donate](https://openpaws.ai/donate) · [Discord](https://discord.gg/openpaws) · [openpaws.ai](https://openpaws.ai) · [Volunteer](https://openpaws.ai/volunteer)


### PR DESCRIPTION
## Summary

- Rewrites README to the Open Paws ecosystem standard template (badge row, TL;DR, NOTE callout, config overview, how-to-apply, contributing, license/acknowledgments, footer)
- All content is derived from the actual `.coderabbit.yaml`, CI workflows, and supporting files in this repo — no fabricated details
- Adds metadata front-matter comments (tech_stack, project_status, difficulty, skill_tags, related_repos) per template spec
- Removes duplicated prose from the old README while preserving all substantive detail (inheritance model, tier classification, auto-merge gate gates, path instructions, static analysis tools, knowledge base settings)

## Test plan

- [ ] Verify rendered Markdown looks correct on GitHub (badges, tables, code blocks, NOTE callout)
- [ ] Confirm all links resolve: no-animal-violence, semgrep-rules, desloppify, context repo, openpaws.ai footer links
- [ ] Check that the tier table and inheritance examples match current `.coderabbit.yaml` behaviour
