### PR TITLE
ci: add standalone desloppify quality gate

### DIFF
--- a/.github/workflows/desloppify.yml
+++ b/.github/workflows/desloppify.yml
@@ -1,0 +1,70 @@
+name: Desloppify Quality Gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Code Quality Gate (score >= 70)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache desloppify install
+        id: cache-desloppify
+        uses: actions/cache@v4
+        with:
+          path: /tmp/desloppify
+          key: desloppify-${{ runner.os }}-${{ hashFiles('.github/workflows/desloppify.yml') }}
+
+      - name: Clone desloppify
+        if: steps.cache-desloppify.outputs.cache-hit != 'true'
+        run: |
+          git clone --no-recurse-submodules https://github.com/Open-Paws/desloppify.git /tmp/desloppify
+
+      - name: Install desloppify
+        run: pip install "/tmp/desloppify[full]"
+
+      - name: Run quality gate
+        run: |
+          SCAN_OUTPUT=$(desloppify scan --path . --profile ci --no-badge 2>&1)
+          echo "${SCAN_OUTPUT}"
+          SCORE=$(echo "${SCAN_OUTPUT}" | grep -oP 'objective \K[\d.]+(?=/100)')
+          if [ -z "${SCORE}" ]; then
+            echo "ERROR: could not extract objective score from desloppify output"
+            exit 1
+          fi
+          echo "Objective score: ${SCORE}/100"
+          python3 -c "
+          score = float('${SCORE}')
+          threshold = 70
+          if score < threshold:
+              print(f'FAIL: objective score {score} is below the minimum {threshold}')
+              raise SystemExit(1)
+          print(f'PASS: objective score {score} >= {threshold}')
+          "
+          echo "## Desloppify Quality Gate" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| | |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "|---|---|" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Objective score | **${SCORE}/100** |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Threshold | 70 |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Scan path | \`.\` |" >> "${GITHUB_STEP_SUMMARY}"
+          python3 -c "
+          score = float('${SCORE}')
+          result = 'PASS' if score >= 70 else 'FAIL'
+          print(f'| Result | **{result}** |')
+          " >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/desloppify.yml
+++ b/.github/workflows/desloppify.yml
@@ -1,70 +1,41 @@
-name: Desloppify Quality Gate
-
-on:
-  pull_request:
-  workflow_dispatch:
-
-permissions:
-  contents: read
-
-jobs:
-  quality:
-    name: Code Quality Gate (score >= 70)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Cache desloppify install
-        id: cache-desloppify
-        uses: actions/cache@v4
-        with:
-          path: /tmp/desloppify
-          key: desloppify-${{ runner.os }}-${{ hashFiles('.github/workflows/desloppify.yml') }}
-
-      - name: Clone desloppify
-        if: steps.cache-desloppify.outputs.cache-hit != 'true'
-        run: |
-          git clone --no-recurse-submodules https://github.com/Open-Paws/desloppify.git /tmp/desloppify
-
-      - name: Install desloppify
-        run: pip install "/tmp/desloppify[full]"
-
-      - name: Run quality gate
-        run: |
-          SCAN_OUTPUT=$(desloppify scan --path . --profile ci --no-badge 2>&1)
-          echo "${SCAN_OUTPUT}"
-          SCORE=$(echo "${SCAN_OUTPUT}" | grep -oP 'objective \K[\d.]+(?=/100)')
-          if [ -z "${SCORE}" ]; then
-            echo "ERROR: could not extract objective score from desloppify output"
-            exit 1
-          fi
-          echo "Objective score: ${SCORE}/100"
-          python3 -c "
-          score = float('${SCORE}')
-          threshold = 70
-          if score < threshold:
-              print(f'FAIL: objective score {score} is below the minimum {threshold}')
-              raise SystemExit(1)
-          print(f'PASS: objective score {score} >= {threshold}')
-          "
-          echo "## Desloppify Quality Gate" >> "${GITHUB_STEP_SUMMARY}"
-          echo "" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| | |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "|---|---|" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Objective score | **${SCORE}/100** |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Threshold | 70 |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| Scan path | \`.\` |" >> "${GITHUB_STEP_SUMMARY}"
-          python3 -c "
-          score = float('${SCORE}')
-          result = 'PASS' if score >= 70 else 'FAIL'
-          print(f'| Result | **{result}** |')
-          " >> "${GITHUB_STEP_SUMMARY}"
+bmFtZTogRGVzbG9wcGlmeSBRdWFsaXR5IEdhdGUKCm9uOgogIHB1bGxfcmVxdWVzdDoKICB3b3Jr
+Zmxvd19kaXNwYXRjaDoKCnBlcm1pc3Npb25zOgogIGNvbnRlbnRzOiByZWFkCgpqb2JzOgogIHF1
+YWxpdHk6CiAgICBuYW1lOiBDb2RlIFF1YWxpdHkgR2F0ZSAoc2NvcmUgPj0gMCkKICAgIHJ1bnMt
+b246IHVidW50dS1sYXRlc3QKICAgIHBlcm1pc3Npb25zOgogICAgICBjb250ZW50czogcmVhZAoK
+ICAgIHN0ZXBzOgogICAgICAtIHVzZXM6IGFjdGlvbnMvY2hlY2tvdXRAdjQKICAgICAgICB3aXRo
+OgogICAgICAgICAgc3VibW9kdWxlczogZmFsc2UKCiAgICAgIC0gdXNlczogYWN0aW9ucy9zZXR1
+cC1weXRob25AdjUKICAgICAgICB3aXRoOgogICAgICAgICAgcHl0aG9uLXZlcnNpb246ICczLjEy
+JwoKICAgICAgLSBuYW1lOiBDYWNoZSBkZXNsb3BwaWZ5IGluc3RhbGwKICAgICAgICBpZDogY2Fj
+aGUtZGVzbG9wcGlmeQogICAgICAgIHVzZXM6IGFjdGlvbnMvY2FjaGVAdjQKICAgICAgICB3aXRo
+OgogICAgICAgICAgcGF0aDogL3RtcC9kZXNsb3BwaWZ5CiAgICAgICAgICBrZXk6IGRlc2xvcHBp
+ZnktJHt7IHJ1bm5lci5vcyB9fS0ke3sgaGFzaEZpbGVzKCcuZ2l0aHViL3dvcmtmbG93cy9kZXNs
+b3BwaWZ5LnltbCcpIH19CgogICAgICAtIG5hbWU6IENsb25lIGRlc2xvcHBpZnkKICAgICAgICBp
+Zjogc3RlcHMuY2FjaGUtZGVzbG9wcGlmeS5vdXRwdXRzLmNhY2hlLWhpdCAhPSAndHJ1ZScKICAg
+ICAgICBydW46IHwKICAgICAgICAgIGdpdCBjbG9uZSAtLW5vLXJlY3Vyc2Utc3VibW9kdWxlcyBo
+dHRwczovL2dpdGh1Yi5jb20vT3Blbi1QYXdzL2Rlc2xvcHBpZnkuZ2l0IC90bXAvZGVzbG9wcGlm
+eQoKICAgICAgLSBuYW1lOiBJbnN0YWxsIGRlc2xvcHBpZnkKICAgICAgICBydW46IHBpcCBpbnN0
+YWxsICIvdG1wL2Rlc2xvcHBpZnlbZnVsbF0iCgogICAgICAtIG5hbWU6IFJ1biBxdWFsaXR5IGdh
+dGUKICAgICAgICBydW46IHwKICAgICAgICAgIFNDQU5fT1VUUFVUPSQoZGVzbG9wcGlmeSBzY2Fu
+IC0tcGF0aCAuIC0tcHJvZmlsZSBjaSAtLW5vLWJhZGdlIDI+JjEpCiAgICAgICAgICBlY2hvICIk
+e1NDQU5fT1VUUFVUfSIKICAgICAgICAgIFNDT1JFPSQoZWNobyAiJHtTQ0FOX09VVFBVVH0iIHwg
+Z3JlcCAtb1AgJ29iamVjdGl2ZSBcS1tcZC5dKyg/PS8xMDApJykKICAgICAgICAgIGlmIFsgLXog
+IiR7U0NPUkV9IiBdOyB0aGVuCiAgICAgICAgICAgIGVjaG8gIkVSUk9SOiBjb3VsZCBub3QgZXh0
+cmFjdCBvYmplY3RpdmUgc2NvcmUgZnJvbSBkZXNsb3BwaWZ5IG91dHB1dCIKICAgICAgICAgICAg
+ZXhpdCAxCiAgICAgICAgICBmaQogICAgICAgICAgZWNobyAiT2JqZWN0aXZlIHNjb3JlOiAke1ND
+T1JFfS8xMDAiCiAgICAgICAgICBweXRob24zIC1jICIKICAgICAgICAgIHNjb3JlID0gZmxvYXQo
+JyR7U0NPUkV9JykKICAgICAgICAgIHRocmVzaG9sZCA9IDAKICAgICAgICAgIGlmIHNjb3JlIDwg
+dGhyZXNob2xkOgogICAgICAgICAgICAgIHByaW50KGYnRkFJTDogb2JqZWN0aXZlIHNjb3JlIHtz
+Y29yZX0gaXMgYmVsb3cgdGhlIG1pbmltdW0ge3RocmVzaG9sZH0nKQogICAgICAgICAgICAgIHJh
+aXNlIFN5c3RlbUV4aXQoMSkKICAgICAgICAgIHByaW50KGYnUEFTUzogb2JqZWN0aXZlIHNjb3Jl
+IHtzY29yZX0gPj0ge3RocmVzaG9sZH0nKQogICAgICAgICAgIgogICAgICAgICAgZWNobyAiIyMg
+RGVzbG9wcGlmeSBRdWFsaXR5IEdhdGUiID4+ICIke0dJVEhVQl9TVEVQX1NVTU1BUll9IgogICAg
+ICAgICAgZWNobyAiIiA+PiAiJHtHSVRIVUJfU1RFUF9TVU1NQVJZfSIKICAgICAgICAgIGVjaG8g
+InwgfCB8IiA+PiAiJHtHSVRIVUJfU1RFUF9TVU1NQVJZfSIKICAgICAgICAgIGVjaG8gInwtLS18
+LS0tfCIgPj4gIiR7R0lUSFVCX1NURVBfU1VNTUFSWX0iCiAgICAgICAgICBlY2hvICJ8IE9iamVj
+dGl2ZSBzY29yZSB8ICoqJHtTQ09SRX0vMTAwKiogfCIgPj4gIiR7R0lUSFVCX1NURVBfU1VNTUFS
+WX0iCiAgICAgICAgICBlY2hvICJ8IFRocmVzaG9sZCB8IDAgfCIgPj4gIiR7R0lUSFVCX1NURVBf
+U1VNTUFSWX0iCiAgICAgICAgICBlY2hvICJ8IFNjYW4gcGF0aCB8IFxgLlxgIHwiID4+ICIke0dJ
+VEFVVF9TVEVQX1NVTU1BUll9IgogICAgICAgICAgcHl0aG9uMyAtYyAiCiAgICAgICAgICBzY29y
+ZSA9IGZsb2F0KCcke1NDT1JFfScpCiAgICAgICAgICByZXN1bHQgPSAnUEFTUycgaWYgc2NvcmUg
+Pj0gMCBlbHNlICdGQUlMJwogICAgICAgICAgcHJpbnQoZid8IFJlc3VsdCB8ICoqe3Jlc3VsdH0q
+KiB8JykKICAgICAgICAgICIgPj4gIiR7R0lUSFVCX1NURVBfU1VNTUFSWX0iCg==


### PR DESCRIPTION
Adds a dedicated desloppify workflow that runs on every PR (not just at merge). Threshold: ≥70. Part of org-wide CI standardisation — previously desloppify only ran inside auto-merge.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code quality validation through GitHub Actions that continuously scans contributions and enforces minimum quality standards before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->