### PR TITLE
chore(docs): drop refs to deleted graze-cli and gary repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,6 @@ There is no staging environment for CodeRabbit config — test in a low-risk rep
 This config is the baseline for **all Open Paws repositories**. It is actively used by:
 
 - `platform` — Astro 5 + React 19 + Supabase frontend/backend
-- `gary` — autonomous agent (overrides with `knowledge_base.opt_out: true`)
-- `graze-cli` — agentic coding CLI
 - `desloppify` — code quality scanner
 - `project-compassionate-code` — org-scale PR submission tool
 - All other repos in the Open-Paws org that lack their own `.coderabbit.yaml`

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ knowledge_base:
 
 | Tier | Examples | Recommended override |
 |---|---|---|
-| Tier 1 (public, no sensitive data) | platform, desloppify, graze-cli | Use org config as-is |
+| Tier 1 (public, no sensitive data) | platform, desloppify | Use org config as-is |
 | Tier 2 (coalition or campaign data) | campaign tooling | `knowledge_base.opt_out: true` |
-| Tier 3 (investigation data, witness info, legal) | investigation ops, gary | `knowledge_base.opt_out: true` |
+| Tier 3 (investigation data, witness info, legal) | investigation ops | `knowledge_base.opt_out: true` |
 
 Tier assignments: `ecosystem/repos.md` in the [context repo](https://github.com/Open-Paws/context).
 


### PR DESCRIPTION
Open-Paws/graze-cli and Open-Paws/gary are being deleted.

- README.md tier table: drop graze-cli (Tier 1 example) and gary (Tier 3 example)
- AGENTS.md integration list: drop graze-cli + gary lines

Closes #15